### PR TITLE
fixed bug in assgnment of ImageEmbedder in viewdata

### DIFF
--- a/src/Postal.AspNetCore/EmailViewRender.cs
+++ b/src/Postal.AspNetCore/EmailViewRender.cs
@@ -66,9 +66,9 @@ namespace Postal
             }
 
             Dictionary<string, object> viewData = new Dictionary<string, object>();
-            viewData[ImageEmbedder.ViewDataKey] = email.ImageEmbedder;
-            viewData.Remove(ImageEmbedder.ViewDataKey);
+            viewData[ImageEmbedder.ViewDataKey] = email.ImageEmbedder;            
             var viewOutput = await _templateService.RenderTemplateAsync(routeData, viewName, email, viewData, true);
+            viewData.Remove(ImageEmbedder.ViewDataKey);
             return viewOutput;
         }
     }


### PR DESCRIPTION
ImageEmbedder instance was getting removed from ViewData before view was rendered resulting is exception if an image is embedded using extension method HTML.EmbedImage()